### PR TITLE
feat: add Mailchimp signup form to homepage

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1987,7 +1987,7 @@ input, select, textarea {
 				.icon.circle.fa-envelope:hover {
 					background:rgb(147, 177, 223)8;
 				}
-			
+
 			.icon.circle.fa-linkedin-in {
 				background: #8393da;
 				color: #fff;

--- a/index.html
+++ b/index.html
@@ -69,6 +69,41 @@
 					</header>
 
 					<section class="wrapper style3 container special">
+						<div id="mc_embed_shell">
+							<div id="mc_embed_signup">
+								<form
+									action="https://ephyragamedev.us2.list-manage.com/subscribe/post?u=5bab79f614315fb99cf5a1739&amp;id=fa990e53ba&amp;f_id=00af6be1f0"
+									method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate"
+									target="_blank">
+									<div id="mc_embed_signup_scroll">
+										<h2>Want to be part of the journey?</h2>
+										<p>By joining our mailing list, you&apos;ll get exclusive early access to game demos, a
+											chance to give feedback on key development decisions, and regular updates on what we're building behind the scenes.
+											Whether you're here to play, contribute, or just stay in the loop, we&apos;d love to have you along for the adventure.</p>
+										<div class="mc-field-group"><input type="email" name="EMAIL" class="required email" id="mce-EMAIL"
+												required="" value=""></div>
+										<div id="mce-responses" class="clear foot">
+											<div class="response" id="mce-error-response" style="display: none;"></div>
+											<div class="response" id="mce-success-response" style="display: none;"></div>
+										</div>
+										<div aria-hidden="true" style="position: absolute; left: -5000px;">
+											/* real people should not fill this in and expect good things - do not remove this or risk form
+											bot
+											signups */
+											<input type="text" name="b_5bab79f614315fb99cf5a1739_fa990e53ba" tabindex="-1" value="">
+										</div>
+										<div style="padding-top: 20px;">
+											<div class="clear foot">
+												<input type="submit" name="subscribe" id="mc-embedded-subscribe" class="button"
+													value="Subscribe">
+											</div>
+										</div>
+									</div>
+								</form>
+							</div>
+					</section>
+
+					<section class="wrapper style3 container special">
 						<header class="major">
 							<h2>Meet Our  <strong>Team</strong></h2>
 						</header>
@@ -91,7 +126,7 @@
 									<p>Sed tristique purus vitae volutpat commodo suscipit amet sed nibh. Proin a ullamcorper sed blandit. Sed tristique purus vitae volutpat commodo suscipit ullamcorper sed blandit lorem ipsum dolore.</p>
 								</section>
 							</div>
-							
+
 						</div>
 						<div class="row">
 							<div class="col-6 col-12-narrower">
@@ -123,7 +158,7 @@
 							</div>
 						</div>
 					</section>
-				</article>			
+				</article>
 
 			<!-- Footer -->
 				<footer id="footer">
@@ -153,6 +188,7 @@
 			<script src="assets/js/breakpoints.min.js"></script>
 			<script src="assets/js/util.js"></script>
 			<script src="assets/js/main.js"></script>
-
+		<!-- Mailchimp -->
+			<script type="text/javascript" src="//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js"></script><script type="text/javascript">(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='BIRTHDAY';ftypes[5]='birthday';fnames[6]='COMPANY';ftypes[6]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script></div>
 	</body>
 </html>


### PR DESCRIPTION
Add Mailchimp signup form to homepage, with pitch for why users should sign up. Trailing whitespace also removed automatically by editor.

# Screenshots

## Wide Desktop

![image](https://github.com/user-attachments/assets/a5e35cb6-230b-4c4a-a158-8068d58710f0)

## Narrow Desktop

![image](https://github.com/user-attachments/assets/17515ac6-2a53-4d13-aa90-45b19339bedf)

## Mobile

![image](https://github.com/user-attachments/assets/7b2ed3b0-a765-4759-9020-55df2b5e39d0)
